### PR TITLE
fix: The system cannot move the file to a different disk drive

### DIFF
--- a/steam_auto_cracker.py
+++ b/steam_auto_cracker.py
@@ -9,7 +9,7 @@ import shutil
 from time import sleep
 import traceback
 
-VERSION = "1.2.4"
+VERSION = "1.2.5"
 
 RETRY_DELAY = 3 # Delay in seconds before retrying a failed request
 RETRY_MAX = 6 # Number of failed tries (includes the first try) after which SAC will stop trying and quit.


### PR DESCRIPTION
Fix bug: The system cannot move the file to a different disk drive
![image](https://user-images.githubusercontent.com/40328498/177969799-2492c003-0099-4510-a5aa-2f023274424d.png)


change `os.rename` to `shutil.move`
I've been reading a bit, and `os.rename` can't move files across different drives in some cases [[docs.python.org](https://docs.python.org/3/library/os.html#os.rename)].

`shutil.move` on the other hand, does. Internally, `shutil.move` uses `os.rename` if the destination path is on the current filesystem, otherwise just copies the file and then deletes the original one [[docs.python.org](https://docs.python.org/3/library/shutil.html#shutil.move)].

`shutil.move` should be used instead of `os.rename`.