### PR TITLE
Trying to make Linux support possible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
-pywin32
+pefile
 tkinterdnd2

--- a/sac_lib/get_file_version.py
+++ b/sac_lib/get_file_version.py
@@ -1,5 +1,17 @@
-import win32api
+import pefile
 
 def GetFileVersion(filename: str) -> str:
-    fileInfos = win32api.GetFileVersionInfo(filename, "\\")
-    return "%d.%d.%d.%d" % (fileInfos['FileVersionMS'] / 65536, fileInfos['FileVersionMS'] % 65536, fileInfos['FileVersionLS'] / 65536, fileInfos['FileVersionLS'] % 65536)
+    pe = pefile.PE(filename)
+
+    if not hasattr(pe, "VS_FIXEDFILEINFO"):
+        return None
+
+    ms = pe.VS_FIXEDFILEINFO[0].FileVersionMS
+    ls = pe.VS_FIXEDFILEINFO[0].FileVersionLS
+
+    major = ms >> 16
+    minor = ms & 0xFFFF
+    build = ls >> 16
+    revision = ls & 0xFFFF
+
+    return f"{major}.{minor}.{build}.{revision}"

--- a/steam_auto_cracker_gui.py
+++ b/steam_auto_cracker_gui.py
@@ -85,7 +85,6 @@ try: # Handles Python errors to write them to a log file so they can be reported
         # Determine the folder path based on the event type
         if event:  # Handling drag and drop
             folder_path_temp = event.data.strip("{}").replace("\\", "/") # Returns the directory with no "/" at the end
-
         else:  # Handling button click
             initial_dir = "/"
             if last_selected_folder != "" and os.path.isdir(last_selected_folder):

--- a/steam_auto_cracker_gui.py
+++ b/steam_auto_cracker_gui.py
@@ -85,11 +85,17 @@ try: # Handles Python errors to write them to a log file so they can be reported
         # Determine the folder path based on the event type
         if event:  # Handling drag and drop
             folder_path_temp = event.data.strip("{}").replace("\\", "/") # Returns the directory with no "/" at the end
+
         else:  # Handling button click
             initial_dir = "/"
             if last_selected_folder != "" and os.path.isdir(last_selected_folder):
                 initial_dir = last_selected_folder
             folder_path_temp = filedialog.askdirectory(initialdir=initial_dir) # Returns the directory with no "/" at the end
+
+            # Fix to work on Linux: Tkinter: tuple → string
+            if isinstance(folder_path_temp, tuple):
+                folder_path_temp = folder_path_temp[0]
+
 
         if os.path.isdir(folder_path_temp):
             folder_path = folder_path_temp


### PR DESCRIPTION
Hi @BigBoiCJ this Pull request fixes some issues that lead to the program not being usable on Linux.

I replaced win32api (pywin32 package) with pefile which works on Linux, MacOS and Windows, not only Windows, it also supports Linux Binaries.

Following issue occured when trying to select a path on linux:
`Traceback (most recent call last):
  File "/usr/lib/python3.12/tkinter/__init__.py", line 1967, in __call__
    return self.func(*args)
           ^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/Coding Stuff/SteamAutoCracker/steam_auto_cracker_gui.py", line 1017, in <lambda>
    selectFolderButton = ttk.Button(root, text="Select a folder", command=lambda: handle_folder_selection())
                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/Coding Stuff/SteamAutoCracker/steam_auto_cracker_gui.py", line 94, in handle_folder_selection
    if os.path.isdir(folder_path_temp):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen genericpath>", line 42, in isdir
TypeError: stat: path should be string, bytes, os.PathLike or integer, not tuple`

I fixed it by turning it into a string.

This solves most Problems for Cross Platform Support but there still is an Issue with Steamless:
`Traceback (most recent call last): File "/usr/lib/python3.12/tkinter/__init__.py", line 1967, in __call__ return self.func(*args) ^^^^^^^^^^^^^^^^ File "/home/user/Desktop/Coding Stuff/SteamAutoCracker/steam_auto_cracker_gui.py", line 411, in CrackGame subprocess.call("Steamless_CLI\\Steamless.CLI.exe " + steamlessOptions + "\"" + fileName + "\"", shell=True, creationflags=subprocess.CREATE_NEW_CONSOLE) # Run Steamless on the game ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AttributeError: module 'subprocess' has no attribute 'CREATE_NEW_CONSOLE'`

Linux doesnt support such creatingflags, aaaaand the steamless file is an .exe so it wont work natively on Linux.
To solve this you probably would have to implement some solution using wine, but then it should also be built in the ui, so that the user is notified (if he uses Linux) that wine will have to be installed to use steamless.

I also added an applist file in this pull request because many people were reporting issues because you now need an api key to get it.


Commit Notes:
- replaced win32api with pefile to work on every platform not only windows
- fixed temp folder path error that occured when excuting on Linux
- Added applist.txt (can be removed later, only as long until a long term solution has been found)
